### PR TITLE
Support Python 2 & 3 simultaneously

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import argparse
 from PIL import Image
@@ -33,6 +34,6 @@ result = cuda.to_cpu(y.data)
 result = result.transpose(0, 2, 3, 1)
 result = result.reshape((result.shape[1:]))
 result = np.uint8(result)
-print time.time() - start, 'sec'
+print(time.time() - start, 'sec')
 
 Image.fromarray(result).save(args.out)


### PR DESCRIPTION
Tested under Python 2.7 and 3.5.

2.7:

```
$ python -V
Python 2.7.6
$ python generate.py sample_images/tubingen.jpg -m models/composition.model -o ../comp.jpg -g 0
0.996065855026 sec
```

3.5:

```
$ python -V
Python 3.5.1 :: Anaconda 4.1.0 (64-bit)
$ python generate.py sample_images/tubingen.jpg -m models/composition.model -o ../comp.jpg -g 0
1.1357989311218262 sec
```
